### PR TITLE
Fix exclude pattern matching to support directory filtering

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,24 +123,40 @@ fn sort_only_workflow(args: &Args) -> Result<(), Box<dyn Error>> {
         let original_count = expanded_input_files.len();
         expanded_input_files.retain(|file_path| {
             for exclude_pattern in &args.exclude_patterns {
-                if let Ok(paths) = glob(exclude_pattern) {
-                    for entry in paths {
-                        if let Ok(excluded_path) = entry {
-                            if let Some(excluded_path_str) = excluded_path.to_str() {
-                                if file_path == excluded_path_str {
-                                    info!("Excluding file: {} (matches pattern: {})", file_path, exclude_pattern);
-                                    return false;
-                                }
+                // Check if the file path contains the exclude pattern as a substring
+                if file_path.contains(exclude_pattern) {
+                    info!("Excluding file: {} (path contains pattern: {})", file_path, exclude_pattern);
+                    return false;
+                }
+                
+                // Check if the exclude pattern matches as a glob pattern against the full path
+                if let Ok(pattern) = glob::Pattern::new(exclude_pattern) {
+                    if pattern.matches(file_path) {
+                        info!("Excluding file: {} (path matches glob pattern: {})", file_path, exclude_pattern);
+                        return false;
+                    }
+                }
+                
+                // Check if any component of the path matches the pattern
+                for component in Path::new(file_path).components() {
+                    if let Some(component_str) = component.as_os_str().to_str() {
+                        if let Ok(pattern) = glob::Pattern::new(exclude_pattern) {
+                            if pattern.matches(component_str) {
+                                info!("Excluding file: {} (path component '{}' matches pattern: {})", file_path, component_str, exclude_pattern);
+                                return false;
                             }
                         }
                     }
                 }
-                // Also check if the filename matches the pattern directly
+                
+                // Check if the filename matches the pattern directly
                 if let Some(filename) = Path::new(file_path).file_name() {
                     if let Some(filename_str) = filename.to_str() {
-                        if glob::Pattern::new(exclude_pattern).map_or(false, |p| p.matches(filename_str)) {
-                            info!("Excluding file: {} (filename matches pattern: {})", file_path, exclude_pattern);
-                            return false;
+                        if let Ok(pattern) = glob::Pattern::new(exclude_pattern) {
+                            if pattern.matches(filename_str) {
+                                info!("Excluding file: {} (filename matches pattern: {})", file_path, exclude_pattern);
+                                return false;
+                            }
                         }
                     }
                 }
@@ -344,6 +360,57 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Remove duplicates from expanded_input_files
     expanded_input_files.sort();
     expanded_input_files.dedup();
+    
+    // Filter out excluded files
+    if !args.exclude_patterns.is_empty() {
+        let original_count = expanded_input_files.len();
+        expanded_input_files.retain(|file_path| {
+            for exclude_pattern in &args.exclude_patterns {
+                // Check if the file path contains the exclude pattern as a substring
+                if file_path.contains(exclude_pattern) {
+                    info!("Excluding file: {} (path contains pattern: {})", file_path, exclude_pattern);
+                    return false;
+                }
+                
+                // Check if the exclude pattern matches as a glob pattern against the full path
+                if let Ok(pattern) = glob::Pattern::new(exclude_pattern) {
+                    if pattern.matches(file_path) {
+                        info!("Excluding file: {} (path matches glob pattern: {})", file_path, exclude_pattern);
+                        return false;
+                    }
+                }
+                
+                // Check if any component of the path matches the pattern
+                for component in Path::new(file_path).components() {
+                    if let Some(component_str) = component.as_os_str().to_str() {
+                        if let Ok(pattern) = glob::Pattern::new(exclude_pattern) {
+                            if pattern.matches(component_str) {
+                                info!("Excluding file: {} (path component '{}' matches pattern: {})", file_path, component_str, exclude_pattern);
+                                return false;
+                            }
+                        }
+                    }
+                }
+                
+                // Check if the filename matches the pattern directly
+                if let Some(filename) = Path::new(file_path).file_name() {
+                    if let Some(filename_str) = filename.to_str() {
+                        if let Ok(pattern) = glob::Pattern::new(exclude_pattern) {
+                            if pattern.matches(filename_str) {
+                                info!("Excluding file: {} (filename matches pattern: {})", file_path, exclude_pattern);
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            true
+        });
+        let excluded_count = original_count - expanded_input_files.len();
+        if excluded_count > 0 {
+            info!("Excluded {} files based on exclude patterns", excluded_count);
+        }
+    }
     
     // Validate that either input_files or path_patterns are provided
     if expanded_input_files.is_empty() && args.path_patterns.is_empty() {


### PR DESCRIPTION
## Summary
- Fixes issue where exclude patterns like `--exclude 'configgen'` had no effect
- Enhances exclude pattern matching with multiple matching strategies
- Applies exclude logic consistently in both sort-only and regular diff modes

## Changes
- ✅ **Substring matching**: `--exclude "target"` excludes files with "target" anywhere in path
- ✅ **Glob pattern matching**: `--exclude "*.tmp"` works against full file paths
- ✅ **Path component matching**: Matches against individual directories and filenames
- ✅ **Comprehensive filename matching**: Enhanced pattern matching for file names
- ✅ **Consistent application**: Works in both sort-only and regular diff workflows

## Before vs After
**Before (broken):**
```bash
# This had no effect
./yabe --sort-only -p "**/*.yaml" --exclude "target"
```

**After (working):**
```bash
# Now excludes all files with "target" in the path
./yabe --sort-only -p "**/*.yaml" --exclude "target"
# Excluded 52 files based on exclude patterns

# Also supports complex patterns
./yabe -p "**/*.yaml" --exclude "*/temp/*" --exclude "build" --exclude "*.secret.yaml"
```

## Test plan
- [x] All tests pass (23/23)
- [x] Exclude functionality verified with test files
- [x] Multiple exclude patterns work correctly
- [x] Both sort-only and regular modes support exclusions

🤖 Generated with [Claude Code](https://claude.ai/code)